### PR TITLE
Do not create unnecessary state map for reduction

### DIFF
--- a/noodler/graph_noodler.py
+++ b/noodler/graph_noodler.py
@@ -173,7 +173,7 @@ class GraphNoodler:
         if aut_union is None:
             return []
 
-        aut_union = mata.Nfa.reduce(aut_union)[0]
+        aut_union = mata.Nfa.reduce(aut_union)
         aut_union.trim()
         aut_union.unify_initial()
         cur_constraints: AutConstraints = query.copy()

--- a/noodler/noodler.py
+++ b/noodler/noodler.py
@@ -105,7 +105,7 @@ def create_unified_query(equation: StringEquation,
         var_auts = aut_l.union(aut_r)
         product: Aut = multiop(list(var_auts), lambda x,y: mata.Nfa.intersection(x,y))
         product.trim()
-        const[var] = mata.Nfa.reduce(product)[0]
+        const[var] = mata.Nfa.reduce(product)
         if const[var].get_num_of_states() == 0:
             return None
 

--- a/noodler/sequery.py
+++ b/noodler/sequery.py
@@ -146,7 +146,7 @@ class SingleSEQuery:
         res = multiop(self.automata_for_side(side), lambda x,y: mata.Nfa.concatenate(x, y))
 
         if minimize:
-            return mata.Nfa.reduce(res)[0]
+            return mata.Nfa.reduce(res)
 
         return res
 


### PR DESCRIPTION
This PR updates Noodler to not create a state map in Python for reduction of NFA if the state map is unused.